### PR TITLE
Speed up fetch by avoiding redirect

### DIFF
--- a/bra_scraper/surfer.py
+++ b/bra_scraper/surfer.py
@@ -2,7 +2,7 @@
 
 import requests
 
-BASE_URL = "http://statistik.bra.se/"
+BASE_URL = "https://statistik.bra.se/"
 INTERFACE_URL = BASE_URL + "solwebb/action/"
 
 class Surfer(object):


### PR DESCRIPTION
When fetching data for many crimes and regions, I noticed that this package would issue a HTTP request, get redirected to HTTPS, then do the request over HTTPS. This adds one round trip and one request for every request performed.

I have found that by starting with HTTPS, one can reduce the number of requests by 50%, and speed it up by about 15%.

Here is a test program which exposes the issue:

```
import logging
from bra_scraper.BRA import BRA

logging.basicConfig(level=logging.DEBUG)

# Intialize scraper
scraper = BRA()

topic = scraper.topic(u"Månads- och kvartalsvis - Land och län 1975-2014, land och region 2015-")
data = topic.query(period_start="2012-01-01",  period_end="2012-02-01", regions=["Hela landet"], crimes=["Totalt antal brott"])
```

This sets up a scraper to query for a particular crime type in a particular region. It also logs all of the requests made.

When doing this, I see the following pattern:

```
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): statistik.bra.se:80
DEBUG:urllib3.connectionpool:http://statistik.bra.se:80 "GET /solwebb/action/start?menykatalogid=1 HTTP/1.1" 302 344
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): statistik.bra.se:443
DEBUG:urllib3.connectionpool:https://statistik.bra.se:443 "GET /solwebb/action/start?menykatalogid=1 HTTP/1.1" 200 None
```

It requests `/solwebb/action/start?menykatalogid=1`, and gets 302 redirected to the HTTPS version of the site. Then, it repeats the same request and gets a 200 response.

Starting with HTTPS reduces the number of requests, and also reduces time required to fetch.

PS: I have found a number of improvements for bra_scraper, which you can see at [my fork](https://github.com/nickodell/bra_scraper). Would you like me to send PRs for them? Is this project still maintained?